### PR TITLE
[tests] Adiciona asserts extras em testGerarBalancoMes

### DIFF
--- a/src/test/java/com/mycompany/oficina/service/SistemaTest.java
+++ b/src/test/java/com/mycompany/oficina/service/SistemaTest.java
@@ -53,9 +53,13 @@ public class SistemaTest {
         Fatura fat = new Fatura(1, new Date(), 200.0, null);
         sis.registrarFatura(fat);
 
-        BalancoMensal b = sis.gerarBalancoMes(DateUtil.toLocalDate(new Date()).getMonthValue(),
-                                               DateUtil.toLocalDate(new Date()).getYear());
+        int mesAtual = DateUtil.toLocalDate(new Date()).getMonthValue();
+        int anoAtual = DateUtil.toLocalDate(new Date()).getYear();
+
+        BalancoMensal b = sis.gerarBalancoMes(mesAtual, anoAtual);
         assertEquals(200.0, b.getReceitas(), 0.01);
         assertEquals(100.0, b.getDespesas(), 0.01);
+        assertEquals(mesAtual, b.getMes());
+        assertEquals(anoAtual, b.getAno());
     }
 }


### PR DESCRIPTION
## Summary
- refine `testGerarBalancoMes` with extra month/year asserts

## Testing
- `mvn fmt:format` *(fails: No plugin found for prefix 'fmt')*
- `mvn test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom)*

------
https://chatgpt.com/codex/tasks/task_e_68621f2cd0888331b5a32830ca0b536b