### PR TITLE
[tests] Add basic regression unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,12 @@
             <artifactId>gson-extras</artifactId>
             <version>0.2.2</version> <!-- Versão atualizada -->
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -46,6 +52,19 @@
                 <version>3.10.1</version>
                 <configuration>
                     <release>${maven.compiler.release}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.coveo</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <version>2.22</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/test/java/com/mycompany/oficina/ClienteRepositoryTest.java
+++ b/src/test/java/com/mycompany/oficina/ClienteRepositoryTest.java
@@ -1,0 +1,34 @@
+package com.mycompany.oficina;
+
+import com.mycompany.oficina.model.Cliente;
+import com.mycompany.oficina.persistence.ClienteRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Basic CRUD tests for ClienteRepository. */
+public class ClienteRepositoryTest extends TestBase {
+    @Test
+    void testCrud() {
+        ClienteRepository repo = new ClienteRepository();
+        int initial = repo.findAll().size();
+
+        Cliente c = new Cliente();
+        c.setId(9999);
+        c.setNome("JUnit");
+        c.setCpf("999.999.999-99");
+
+        repo.add(c);
+        assertEquals(initial + 1, repo.findAll().size());
+        Optional<Cliente> loaded = repo.findById(9999);
+        assertTrue(loaded.isPresent());
+        assertEquals("JUnit", loaded.get().getNome());
+
+        c.setNome("Updated");
+        assertTrue(repo.update(c));
+        assertEquals("Updated", repo.findById(9999).get().getNome());
+
+        assertTrue(repo.remove(9999));
+        assertEquals(initial, repo.findAll().size());
+    }
+}

--- a/src/test/java/com/mycompany/oficina/ProdutoRepositoryTest.java
+++ b/src/test/java/com/mycompany/oficina/ProdutoRepositoryTest.java
@@ -1,0 +1,27 @@
+package com.mycompany.oficina;
+
+import com.mycompany.oficina.model.Produto;
+import com.mycompany.oficina.persistence.ProdutoRepository;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Basic CRUD tests for ProdutoRepository. */
+public class ProdutoRepositoryTest extends TestBase {
+    @Test
+    void testCrud() {
+        ProdutoRepository repo = new ProdutoRepository();
+        int initial = repo.findAll().size();
+
+        Produto p = new Produto(9999, "Peça Teste", 5.0);
+        repo.add(p);
+        assertEquals(initial + 1, repo.findAll().size());
+        assertTrue(repo.findById(9999).isPresent());
+
+        Produto updated = new Produto(9999, "Peça Nova", 8.0);
+        repo.update(updated);
+        assertEquals("Peça Nova", repo.findById(9999).get().getNome());
+
+        assertTrue(repo.remove(9999));
+        assertEquals(initial, repo.findAll().size());
+    }
+}

--- a/src/test/java/com/mycompany/oficina/SistemaTest.java
+++ b/src/test/java/com/mycompany/oficina/SistemaTest.java
@@ -1,0 +1,86 @@
+package com.mycompany.oficina;
+
+import com.mycompany.oficina.model.Cliente;
+import com.mycompany.oficina.service.Sistema;
+import java.util.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Tests covering Q15-Q18 logic in Sistema. */
+public class SistemaTest extends TestBase {
+
+    @Test
+    void testIteratorVsForeach() {
+        List<Cliente> list = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            Cliente c = new Cliente();
+            c.setId(i);
+            c.setNome("C" + i);
+            c.setCpf("000" + i);
+            list.add(c);
+        }
+        List<Integer> iter = new ArrayList<>();
+        Iterator<Cliente> it = list.iterator();
+        while (it.hasNext()) {
+            iter.add(it.next().getId());
+        }
+        List<Integer> foreach = new ArrayList<>();
+        for (Cliente c : list) {
+            foreach.add(c.getId());
+        }
+        assertEquals(iter, foreach);
+    }
+
+    @Test
+    void testComparators() {
+        Cliente a = new Cliente();
+        a.setId(1);
+        a.setNome("B");
+        a.setCpf("2");
+        Cliente b = new Cliente();
+        b.setId(2);
+        b.setNome("A");
+        b.setCpf("1");
+        List<Cliente> list = Arrays.asList(a, b);
+
+        list.sort(Cliente.comparatorPorCpf());
+        assertEquals("1", list.get(0).getCpf());
+
+        list.sort(Cliente.comparatorPorNome());
+        assertEquals("A", list.get(0).getNome());
+    }
+
+    @Test
+    void testBuscarComIterator() {
+        Sistema sistema = new Sistema();
+        List<Cliente> list = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            Cliente c = new Cliente();
+            c.setId(i);
+            list.add(c);
+        }
+        Cliente target = list.get(3);
+        Comparator<Cliente> cmp = Comparator.comparingInt(Cliente::getId);
+        Cliente viaIterator = sistema.buscarComIterator(list, target, cmp);
+        Collections.sort(list, cmp);
+        int idx = Collections.binarySearch(list, target, cmp);
+        Cliente viaBinary = list.get(idx);
+        assertEquals(viaBinary, viaIterator);
+    }
+
+    @Test
+    void testSimularFluxoCliente() {
+        Sistema sistema = new Sistema();
+        int baseClientes = sistema.getClientes().size();
+        int baseOrdens = sistema.getOrdens().size();
+        int baseFaturas = sistema.getFaturas().size();
+
+        for (int i = 0; i < 10; i++) {
+            sistema.simularFluxoCliente(1000 + i);
+        }
+
+        assertEquals(baseClientes + 10, sistema.getClientes().size());
+        assertEquals(baseOrdens + 10, sistema.getOrdens().size());
+        assertEquals(baseFaturas + 10, sistema.getFaturas().size());
+    }
+}

--- a/src/test/java/com/mycompany/oficina/TestBase.java
+++ b/src/test/java/com/mycompany/oficina/TestBase.java
@@ -1,0 +1,55 @@
+package com.mycompany.oficina;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.Comparator;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+/** Utility base class that sets a temporary working directory with a copy
+ * of the data folder so CRUD tests don't alter the repository files. */
+public abstract class TestBase {
+    private Path tempDir;
+    private String originalDir;
+
+    @BeforeEach
+    void setup() throws IOException {
+        originalDir = System.getProperty("user.dir");
+        tempDir = Files.createTempDirectory("oficina-test-");
+        Path src = Paths.get(originalDir, "data");
+        Path dest = tempDir.resolve("data");
+        copyRecursive(src, dest);
+        System.setProperty("user.dir", tempDir.toString());
+    }
+
+    @AfterEach
+    void cleanup() throws IOException {
+        System.setProperty("user.dir", originalDir);
+        try (Stream<Path> walk = Files.walk(tempDir)) {
+            walk.sorted(Comparator.reverseOrder())
+                .forEach(p -> {
+                    try {
+                        Files.deleteIfExists(p);
+                    } catch (IOException e) {
+                        // ignore cleanup errors
+                    }
+                });
+        }
+    }
+
+    private static void copyRecursive(Path src, Path dest) throws IOException {
+        Files.createDirectories(dest);
+        try (Stream<Path> stream = Files.walk(src)) {
+            for (Path path : (Iterable<Path>) stream::iterator) {
+                Path relative = src.relativize(path);
+                Path target = dest.resolve(relative.toString());
+                if (Files.isDirectory(path)) {
+                    Files.createDirectories(target);
+                } else {
+                    Files.copy(path, target, StandardCopyOption.REPLACE_EXISTING);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit dependency and plugins
- implement `TestBase` helper that copies the `data` folder for tests
- cover CRUD for `ClienteRepository` and `ProdutoRepository`
- cover Q15–Q18 logic in `Sistema` with unit tests

## Testing
- `mvn fmt:format` *(fails: No plugin found for prefix 'fmt')*
- `mvn -q test` *(fails: Could not resolve plugin dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6862dbde1564833185cb76a31c4bc013